### PR TITLE
refactor: Switch `CacheOptions.shared` to an enum

### DIFF
--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -4,13 +4,13 @@
 use std::time::SystemTime;
 
 use http::{header, request, response, Request, Response};
-use http_cache_semantics::{CacheOptions, CachePolicy, ResponseLike};
+use http_cache_semantics::{CacheOptions, CachePolicy, Privacy, ResponseLike};
 
 mod stub;
 
 fn private_opts() -> CacheOptions {
     CacheOptions {
-        shared: false,
+        privacy: Privacy::Private,
         ..Default::default()
     }
 }


### PR DESCRIPTION
Mostly because it's a lil confusing for the default to be `true`. There are a couple of other non-default fields, but I'm not sure if they're worth new-typing